### PR TITLE
Integrate with TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: android
+sudo: required
+dist: trusty
+
+env:
+  global:
+    - ANDROID_API=29
+    - ANDROID_BUILD_TOOLS=28.0.3
+
+android:
+  components:
+    - tools
+    - platform-tools
+    - build-tools-$ANDROID_BUILD_TOOLS
+    - android-$ANDROID_API
+  licenses:
+    - '.+'
+
+script: gradle clean test
+
+before_install:
+  - yes | sdkmanager "platforms;android-28"
+  - wget http://services.gradle.org/distributions/gradle-5.3-bin.zip
+  - unzip -qq gradle-5.3-bin.zip
+  - export GRADLE_HOME=$PWD/gradle-5.3
+  - export PATH=$GRADLE_HOME/bin:$PATH
+  - gradle -v

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,8 @@
 buildscript {
+    if (!project.hasProperty('version') || project.version == 'unspecified') {
+        project.version = '+'
+    }
+
     repositories {
         google()
         mavenLocal()


### PR DESCRIPTION
replace missing project.version value with "+"

there could be a cleaner place to put this logic, but that is the only place I could find that would execute before the `buildscript` task. I tried a custom task that depended on `buildscript`, but apparently `buildscript` isn't a task, rather it is hardcoded method in the `Project` class 🤔 

works for me if it works for you

If this is approved, I am going to apply this exact commit to each Kit