### PR TITLE
feat: Add Support For FB App ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,5 +42,5 @@ android {
 
 dependencies {
     testImplementation  files('libs/java-json.jar')
-    api 'com.adjust.sdk:adjust-android:4.33.3'
+    api 'com.adjust.sdk:adjust-android:4.38.3'
 }

--- a/src/main/kotlin/com/mparticle/kits/AdjustKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AdjustKit.kt
@@ -51,6 +51,10 @@ class AdjustKit : KitIntegration(), OnAttributionChangedListener, ActivityLifecy
             config.setLogLevel(LogLevel.VERBOSE)
         }
         config.setEventBufferingEnabled(false)
+        val fbAppId = getSettings()[FB_APP_ID_KEY]
+        if (fbAppId != null) {
+            config.setFbAppId(fbAppId);
+        }
         Adjust.onCreate(config)
         setAdidIntegrationAttribute()
         (context.applicationContext as Application).registerActivityLifecycleCallbacks(this)
@@ -115,8 +119,9 @@ class AdjustKit : KitIntegration(), OnAttributionChangedListener, ActivityLifecy
     }
 
     companion object {
-        private const val APP_TOKEN = "appToken"
+        const val APP_TOKEN = "appToken"
         private const val ADJUST_ID_KEY = "adid"
+        const val FB_APP_ID_KEY = "fbAppId"
         private const val KIT_NAME = "Adjust"
 
         var deeplinkResponseListenerProxy: OnDeeplinkEventListener? = null

--- a/src/main/kotlin/com/mparticle/kits/AdjustKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AdjustKit.kt
@@ -119,9 +119,9 @@ class AdjustKit : KitIntegration(), OnAttributionChangedListener, ActivityLifecy
     }
 
     companion object {
-        const val APP_TOKEN = "appToken"
+        private const val APP_TOKEN = "appToken"
         private const val ADJUST_ID_KEY = "adid"
-        const val FB_APP_ID_KEY = "fbAppId"
+        private const val FB_APP_ID_KEY = "fbAppId"
         private const val KIT_NAME = "Adjust"
 
         var deeplinkResponseListenerProxy: OnDeeplinkEventListener? = null

--- a/src/test/kotlin/com/mparticle/kits/AdjustKitTests.kt
+++ b/src/test/kotlin/com/mparticle/kits/AdjustKitTests.kt
@@ -33,6 +33,8 @@ class AdjustKitTests {
             val kit = kit
             val settings = HashMap<String, String>()
             settings["fake setting"] = "fake"
+            settings[AdjustKit.APP_TOKEN] = "test"
+            settings[AdjustKit.FB_APP_ID_KEY] = "test"
             kit.onKitCreate(settings, Mockito.mock(Context::class.java))
         } catch (ex: Exception) {
             e = ex

--- a/src/test/kotlin/com/mparticle/kits/AdjustKitTests.kt
+++ b/src/test/kotlin/com/mparticle/kits/AdjustKitTests.kt
@@ -33,8 +33,14 @@ class AdjustKitTests {
             val kit = kit
             val settings = HashMap<String, String>()
             settings["fake setting"] = "fake"
-            settings[AdjustKit.APP_TOKEN] = "test"
-            settings[AdjustKit.FB_APP_ID_KEY] = "test"
+            val appToken = AdjustKit::class.java.getDeclaredField("APP_TOKEN")
+            appToken.isAccessible = true
+            val token = appToken.get(AdjustKit.Companion) as String
+            settings[token] = "test1"
+            val fbAppId = AdjustKit::class.java.getDeclaredField("FB_APP_ID_KEY")
+            fbAppId.isAccessible = true
+            val fbId = fbAppId.get(AdjustKit.Companion) as String
+            settings[fbId] = "test2"
             kit.onKitCreate(settings, Mockito.mock(Context::class.java))
         } catch (ex: Exception) {
             e = ex


### PR DESCRIPTION
## Summary
 - Updated to latest version of Adjust and updated the kit to listen for fbAppId and set it on Adjust if available.

 ## Testing Plan
 - Tested locally and added some basic unit tests where possible

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6334
