### PR TITLE
feat: Update to Partner latest version 5.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,5 +47,5 @@ android {
 
 dependencies {
     testImplementation  files('libs/java-json.jar')
-    api 'com.adjust.sdk:adjust-android:4.38.3'
+    api 'com.adjust.sdk:adjust-android:5.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ apply plugin: 'kotlin-android'
 
 android {
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
     }
     testOptions {
         unitTests.all {

--- a/src/test/kotlin/com/mparticle/kits/AdjustKitTests.kt
+++ b/src/test/kotlin/com/mparticle/kits/AdjustKitTests.kt
@@ -63,19 +63,6 @@ class AdjustKitTests {
         Assert.fail("$className not found as a known integration.")
     }
 
-    @Test
-    @Throws(JSONException::class)
-    fun testAttributionToJSON() {
-        val originalAttributionJSON = attributionJSON
-        val attribution = AdjustAttribution.fromJson(
-            originalAttributionJSON,
-            originalAttributionJSON.getString("adid"),
-            "android"
-        )
-        val attributionJSON = toJSON(attribution)
-        Assert.assertEquals(originalAttributionJSON.toString(), attributionJSON.toString())
-    }
-
     @get:Throws(JSONException::class)
     private val attributionJSON: JSONObject
          get() {


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Update Adjust kit to version 5.0.0 (latest version)
 - Update `onCreate` method to `initSdk`method 
 - Update `setOnDeeplinkResponseListener ` method to `setOnDeferredDeeplinkResponseListener `
 - `setEnabled` has been removed in version 5.0.0.  `Adjust.enable()` and `Adjust.disable()` methods have been implemented as replacements.
 - Removed `Adjust.onResume()` and ` Adjust.onPause()` methods, as ActivityLifecycleCallbacks functionality is handled by the Adjust SDK.
 -  `adid` methods have been updated to run asynchronously in the latest version, and their signatures have been modified.
 - `adid` property has been removed from the AdjustAttribution class.
 - `fromJson` method has been removed from AdjustAttribution class.
 - `setEventBufferingEnabled ` method has been removed.
 - Changed Minimum SDK to 21

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Ran unit tests and verified functionality with sample application

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6610
